### PR TITLE
fixed jshint errors in generated code

### DIFF
--- a/thrift/compiler/generate/t_js_generator.cc
+++ b/thrift/compiler/generate/t_js_generator.cc
@@ -530,9 +530,9 @@ void t_js_generator::generate_js_struct_definition(ofstream& out,
 
   if (gen_node_ && is_exception) {
       out << indent() << "Thrift.TException.call(this, \"" <<
-          js_namespace(tstruct->get_program()) << tstruct->get_name() << "\")" << endl;
+          js_namespace(tstruct->get_program()) << tstruct->get_name() << "\");" << endl;
       out << indent() << "this.name = \"" <<
-          js_namespace(tstruct->get_program()) << tstruct->get_name() << "\"" << endl;
+          js_namespace(tstruct->get_program()) << tstruct->get_name() << "\";" << endl;
   }
 
   //members with arguments
@@ -789,9 +789,9 @@ void t_js_generator::generate_service_processor(t_service* tservice) {
 
     scope_up(f_service_);
 
-    f_service_ << indent() << "this._handler = handler" << endl;
+    f_service_ << indent() << "this._handler = handler;" << endl;
 
-    scope_down(f_service_);
+    scope_down(f_service_, true);
 
     if (tservice->get_extends() != nullptr) {
         indent(f_service_) << "Thrift.inherits(" <<
@@ -819,7 +819,7 @@ void t_js_generator::generate_service_processor(t_service* tservice) {
                << indent() << "  output.flush();" << endl
                << indent() << "}" << endl;
 
-    scope_down(f_service_);
+    scope_down(f_service_, true);
     f_service_ << endl;
 
     // Generate the process subfunctions
@@ -877,11 +877,11 @@ void t_js_generator::generate_process_function(t_service* tservice,
     if (!first) {
         f_service_ << ", ";
     }
-    f_service_ << "function (err, result) {" << endl;
+    f_service_ << "function (err, ret) {" << endl;
     indent_up();
 
     f_service_ <<
-      indent() << "var result = new " << resultname << "((err != null ? err : {success: result}));" << endl <<
+      indent() << "var result = new " << resultname << "((err !== null ? err : {success: ret}));" << endl <<
       indent() << "output.writeMessageBegin(\"" << tfunction->get_name() <<
         "\", Thrift.MessageType.REPLY, seqid);" << endl <<
       indent() << "result.write(output);" << endl <<
@@ -889,9 +889,9 @@ void t_js_generator::generate_process_function(t_service* tservice,
       indent() << "output.flush();" << endl;
 
     indent_down();
-    indent(f_service_) << "})" << endl;
+    indent(f_service_) << "});" << endl;
 
-    scope_down(f_service_);
+    scope_down(f_service_, true);
     f_service_ << endl;
 }
 

--- a/thrift/compiler/generate/t_oop_generator.h
+++ b/thrift/compiler/generate/t_oop_generator.h
@@ -47,9 +47,13 @@ class t_oop_generator : public t_generator {
     indent_up();
   }
 
-  void scope_down(std::ostream& out) {
+  void scope_down(std::ostream& out, bool semicolon = false) {
     indent_down();
-    indent(out) << "}" << std::endl;
+    indent(out) << "}";
+    if (semicolon) {
+       out << ";";
+    }
+    out << std::endl;
   }
 
   std::string upcase_string(std::string original) {


### PR DESCRIPTION
added missing semicolons here and there
use ==! to compare against null

at least jshint passed with my test thrift file

```
struct Location {
    1: required i32 latitude;
    2: required i32 longitude;
}

struct Something {
  1: map<string, string> ohMap;
  2: i16 ohInt;
}

exception ImAMokey {
  1: string hmm;
}

service GeoLookup {
    string lookup(1: Location loc);
    string hello(1: i32 x, 2: i32 y) throws (1: ImAMokey monkey);
}
```

reviewers: @Raynos @jcorbin 
