### PR TITLE
flush protocol object instead of transport

### DIFF
--- a/thrift/compiler/generate/t_js_generator.cc
+++ b/thrift/compiler/generate/t_js_generator.cc
@@ -1096,7 +1096,7 @@ void t_js_generator::generate_service_client(t_service* tservice) {
       indent() << outputVar << ".writeMessageEnd();" << endl;
 
     if (gen_node_) {
-      f_service_ << indent() << "return this.output.flush();" << endl;
+      f_service_ << indent() << "return output.flush();" << endl;
     } else {
       if (gen_jquery_) {
         f_service_ << indent() << "return this.output.getTransport().flush(callback);" << endl;


### PR DESCRIPTION
the old code generates this

```
var GeoLookupClient = exports.Client = function(output, pClass) {
    this.output = output;
    this.pClass = pClass;
    this.seqid = 0;
    this._reqs = {};
};
GeoLookupClient.prototype = {};
GeoLookupClient.prototype.lookup = function(loc, callback) {
  this.seqid += 1;
  this._reqs[this.seqid] = callback;
  this.send_lookup(loc);
};

GeoLookupClient.prototype.send_lookup = function(loc) {
  var output = new this.pClass(this.output);
  output.writeMessageBegin('lookup', Thrift.MessageType.CALL, this.seqid);
  var args = new GeoLookup_lookup_args();
  args.loc = loc;
  args.write(output);
  output.writeMessageEnd();
  return this.output.flush(); <<<<<<<<<<< here should flush protocol, should be return output.flush();
};
```

`var output` is the protocol object while `this.output` is the transport
the generated Client flushes transport which is on the wrong level. (the Process code does the right thing) Instead, it should flush protocol. the builtin protocols such as TBinaryProtocol and TFramedProtocol call transport flush on flush protocol itself. so this change shouldn't break anything. but it makes customized protocol less awkward
